### PR TITLE
Bugfix: Not discarding disallowed CSS rules

### DIFF
--- a/styles/ninja-forms-styles.php
+++ b/styles/ninja-forms-styles.php
@@ -281,7 +281,7 @@ final class NF_Styles
                                     break;
                                 case 'display':
                                 case 'float':
-                                    continue;
+                                    continue 2;
                                 default:
                                     $selector = '.ninja-forms-field';
                                     $styles[ '.nf-field-element > div' ][ $element ] = $style;
@@ -344,7 +344,7 @@ final class NF_Styles
                                         case 'float':
                                         case 'height':
                                         case 'width':
-                                            continue;
+                                            continue 2;
                                     }
                                 }
                             }
@@ -365,7 +365,7 @@ final class NF_Styles
                                         case 'float':
                                         case 'height':
                                         case 'width':
-                                            continue;
+                                            continue 2;
                                     }
                                 }
                             }
@@ -386,7 +386,7 @@ final class NF_Styles
                                         case 'float':
                                         case 'height':
                                         case 'width':
-                                            continue;
+                                            continue 2;
                                     }
 
                                     if( 'color' == $rule ){
@@ -414,7 +414,7 @@ final class NF_Styles
                                             break;
                                         case 'display':
                                         case 'float':
-                                            continue;
+                                            continue 2;
                                         default:
                                             $selector = '.ninja-forms-field';
                                             $styles[ str_replace( '{field-type}' , $field_type, $base_selector ) . ' .nf-field-element > div' ][ $rule ] = $value;
@@ -585,7 +585,7 @@ final class NF_Styles
                                     case 'float':
                                     case 'height':
                                     case 'width':
-                                        continue;
+                                        continue 2;
                                 }
 
                                 if( 'color' == $rule ){
@@ -611,7 +611,7 @@ final class NF_Styles
                                     break;
                                 case 'display':
                                 case 'float':
-                                    continue;
+                                    continue 2;
                                 default:
                                     $selector = '.ninja-forms-field';
                                     $styles[ ' .nf-field-element > div' ][ $rule ] = $field_setting;
@@ -636,7 +636,7 @@ final class NF_Styles
                                     break;
                                 case 'display':
                                 case 'float':
-                                    continue;
+                                    continue 2;
                             }
                         }
 
@@ -655,7 +655,7 @@ final class NF_Styles
                                 case 'float':
                                 case 'height':
                                 case 'width':
-                                    continue;
+                                    continue 2;
                             }
                         }
                     }


### PR DESCRIPTION
The `continue` lines were acting like `break`s and having no effect rather than breaking out of the enclosing `foreach`. 

Fixes new warnings in PHP 7.3:
PHP Warning:  "continue" targeting switch is equivalent to "break". Did you mean to use "continue 2"? in [...]/ninja-forms-layout-styles/styles/ninja-forms-styles.php on line 284

From the docs:
    Note: In PHP the switch statement is considered a looping structure for the purposes of continue. continue behaves like break (when no arguments are passed) but will raise a warning as this is likely to be a mistake. If a switch is inside a loop, continue 2 will continue with the next iteration of the outer loop. 
<https://www.php.net/manual/en/control-structures.continue.php>